### PR TITLE
Revert "Add helper to check if string is only spaces"

### DIFF
--- a/shell.h
+++ b/shell.h
@@ -26,6 +26,5 @@ char **tokenize_line(char *line);
  * @argv: The array to free
  */
 void free_argv(char **argv);
-int only_spaces(char *line);
 
 #endif

--- a/simple-shell.c
+++ b/simple-shell.c
@@ -4,21 +4,6 @@
 #include <sys/wait.h>
 #include <string.h>
 #include "shell.h"
-#include <ctype.h>
-int only_spaces(char *line)
-{
-	int i = 0, result = 0;
-
-	while (line[i] != '\0')
-	{
-		if (isspace(line[i]))
-			result = 1;
-		else
-			result = 0;
-		i++;
-	}
-	return (result);
-}
 /**
  * main - entrypoint to simple shell
  * @ac: Number of args passed to the program
@@ -49,10 +34,6 @@ int main(int ac, char **av)
 			break;
 		}
 		line[strcspn(line, "\n")] = '\0';
-		if (only_spaces(line) == 1)
-		{
-			break;
-		}
 		av = tokenize_line(line);
 		child = fork();
 


### PR DESCRIPTION
Reverts shihuaxie/holbertonschool-simple_shell#15

Reverting because the fix used a library function that's not allowed by the checker:
> Function '__ctype_b_loc' is not allowed