### PR TITLE
Kb/handle input of only spaces

### DIFF
--- a/shell.h
+++ b/shell.h
@@ -26,5 +26,6 @@ char **tokenize_line(char *line);
  * @argv: The array to free
  */
 void free_argv(char **argv);
+int only_spaces(char *line);
 
 #endif

--- a/simple-shell.c
+++ b/simple-shell.c
@@ -4,7 +4,11 @@
 #include <sys/wait.h>
 #include <string.h>
 #include "shell.h"
-
+/**
+ * only_spaces - searches a string to check for only_spaces
+ * @line: string to check
+ * Return: 1 if line is only spaces or tabs, 0 if other characters found
+ */
 int only_spaces(char *line)
 {
 	int i = 0;

--- a/simple-shell.c
+++ b/simple-shell.c
@@ -4,6 +4,20 @@
 #include <sys/wait.h>
 #include <string.h>
 #include "shell.h"
+
+int only_spaces(char *line)
+{
+	int i = 0;
+
+	while (line[i] != '\0')
+	{
+		if (line[i] != ' ' && line[i] != '\t')
+			return (0);
+		i++;
+	}
+	return (1);
+}
+
 /**
  * main - entrypoint to simple shell
  * @ac: Number of args passed to the program
@@ -34,6 +48,11 @@ int main(int ac, char **av)
 			break;
 		}
 		line[strcspn(line, "\n")] = '\0';
+		if (line[0] == ' ')
+		{
+			if (only_spaces(line) == 1)
+				break;
+		}
 		av = tokenize_line(line);
 		child = fork();
 


### PR DESCRIPTION
**Second attempt to handle spaces-only input**
This PR modifies a helper function which checks whether the input consists of only spaces. For the first attempt, I used a library which turned out to be disallowed by the checker, so I rewrote the helper to avoid the library. 

NB: I'm still not certain that a break is the behaviour we actually want in this case.