### PR TITLE
Return status inside while loop

### DIFF
--- a/simple-shell.c
+++ b/simple-shell.c
@@ -95,9 +95,12 @@ int main(int ac, char **av)
 			wait(&status);
 
 			if (WIFEXITED(status))
+			{
 				exec_return = WEXITSTATUS(status);
+			}
 			else
 				exec_return = 1;
+			return (exec_return);
 		}
 
 		free_argv(av);


### PR DESCRIPTION
Task 5 checker is failing on _execute a command that fails, and exit without parameter_
**Checker Output**
```
[exec_bash_compare] Student stdout:
(command)[echo "/bin/ls /test_hbtn
exit" | ./hsh]
[GOT]:
(stdout)[](Length: 0)
(stderr)[/bin/ls: cannot access '/test_hbtn': No such file or directory
](Length: 63)
(status)[0]
[EXPECTED]:
(stdout)[](Length: 0)
(stderr)[/bin/ls: cannot access '/test_hbtn': No such file or directory
](Length: 63)
(status)[2]
```
The only difference in output is for status. I verified that `exec_return` does end up with the correct value for the test case, which suggests that the code doesn't reach the return (exec_return) statement. In this PR, I'm testing out whether returning status inside the while loop fixes the bug. 