### PR TITLE
WIP/remove extern ref from c files

### DIFF
--- a/simple-shell.c
+++ b/simple-shell.c
@@ -5,7 +5,6 @@
 #include <string.h>
 #include "shell.h"
 
-extern char **environ;
 char *find_command(char *command);
 
 /**


### PR DESCRIPTION
Fix for
> WARNING: externs should be avoided in .c files