### PR TITLE
Remove extern from builtin.c

### DIFF
--- a/builtins.c
+++ b/builtins.c
@@ -3,8 +3,6 @@
 #include <stdio.h>
 #include "shell.h"
 
-extern char **environ;
-
 /**
  * handle_builtin - check and executes built-in commands
  * @argv: parsed command arguments


### PR DESCRIPTION
Fix for betty:
> ========== builtins.c ==========
> builtins.c:6: WARNING: externs should be avoided in .c files